### PR TITLE
Feature/offline maps

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -9,6 +9,7 @@ import {
   Switch,
 } from 'react-native';
 import { PROVIDER_GOOGLE, PROVIDER_OSMDROID, PROVIDER_DEFAULT } from 'react-native-maps';
+import LocalCustomTiles from './examples/LocalCustomTiles';
 import DisplayLatLng from './examples/DisplayLatLng';
 import ViewsAsMarkers from './examples/ViewsAsMarkers';
 import EventListener from './examples/EventListener';
@@ -137,6 +138,7 @@ class App extends React.Component {
   render() {
     return this.renderExamples([
       // [<component>, <component description>, <Google compatible>, <Google add'l description>]
+      [LocalCustomTiles, 'LocalCustomTiles', true],
       [StaticMap, 'StaticMap', true],
       [DisplayLatLng, 'Tracking Position', true, '(incomplete)'],
       [ViewsAsMarkers, 'Arbitrary Views as Markers', true],

--- a/example/examples/LocalCustomTiles.js
+++ b/example/examples/LocalCustomTiles.js
@@ -1,0 +1,110 @@
+import React from 'react';
+import {
+  StyleSheet,
+  View,
+  Text,
+  Dimensions,
+} from 'react-native';
+
+import MapView, { MAP_TYPES, PROVIDER_DEFAULT, ProviderPropType, UrlTile, FileTile } from 'react-native-maps';
+
+const { width, height } = Dimensions.get('window');
+
+const ASPECT_RATIO = width / height;
+const LATITUDE = 37.78825;
+const LONGITUDE = -122.4324;
+const LATITUDE_DELTA = 0.0922;
+const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
+
+class LocalCustomTiles extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+
+    this.state = {
+      region: {
+        latitude: 46.947975,
+        longitude: 7.447447,
+        latitudeDelta: 0.0922,
+        longitudeDelta: 0.0421,
+      },
+    };
+  }
+
+  get mapType() {
+    // MapKit does not support 'none' as a base map
+    return this.props.provider === PROVIDER_DEFAULT ?
+      MAP_TYPES.STANDARD : MAP_TYPES.NONE;
+  }
+
+  render() {
+    const { region } = this.state;
+    return (
+      <View style={styles.container}>
+        <MapView
+          provider={this.props.provider}
+          mapType={this.mapType}
+          style={styles.map}
+          initialRegion={region}
+        >
+          <FileTile
+            maximumZ={14}
+            minimumZ={12}
+            shouldReplaceMapContent={true}
+          />
+        </MapView>
+        <View style={styles.buttonContainer}>
+          <View style={styles.bubble}>
+            <Text>Custom Tiles</Text>
+          </View>
+        </View>
+      </View>
+    );
+  }
+}
+
+LocalCustomTiles.propTypes = {
+  provider: ProviderPropType,
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  map: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  bubble: {
+    flex: 1,
+    backgroundColor: 'rgba(255,255,255,0.7)',
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    borderRadius: 20,
+  },
+  latlng: {
+    width: 200,
+    alignItems: 'stretch',
+  },
+  button: {
+    width: 80,
+    paddingHorizontal: 12,
+    alignItems: 'center',
+    marginHorizontal: 10,
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    marginVertical: 20,
+    backgroundColor: 'transparent',
+  },
+});
+
+export default LocalCustomTiles;

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ export { default as Polyline } from './lib/components/MapPolyline.js';
 export { default as Polygon } from './lib/components/MapPolygon.js';
 export { default as Circle } from './lib/components/MapCircle.js';
 export { default as UrlTile } from './lib/components/MapUrlTile.js';
+export { default as FileTile } from './lib/components/MapFileTile.js';
 export { default as LocalTile } from './lib/components/MapLocalTile.js';
 export { default as Callout } from './lib/components/MapCallout.js';
 export { default as AnimatedRegion } from './lib/components/AnimatedRegion.js';

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 
 import com.airbnb.android.react.maps.osmdroid.OsmMapCalloutManager;
 import com.airbnb.android.react.maps.osmdroid.OsmMapCircleManager;
+import com.airbnb.android.react.maps.osmdroid.OsmMapFileTile;
+import com.airbnb.android.react.maps.osmdroid.OsmMapFileTileManager;
 import com.airbnb.android.react.maps.osmdroid.OsmMapManager;
 import com.airbnb.android.react.maps.osmdroid.OsmMapMarkerManager;
 import com.airbnb.android.react.maps.osmdroid.OsmMapPolygonManager;
@@ -78,6 +80,7 @@ public class MapsPackage implements ReactPackage {
       OsmMapCircleManager osmMapCircleManager = new OsmMapCircleManager(reactContext);
       OsmMapManager osmMapManager = new OsmMapManager(reactContext);
       OsmMapUrlTileManager osmUrlTileManager = new OsmMapUrlTileManager();
+      OsmMapFileTileManager osmMapFileTileManager = new OsmMapFileTileManager();
 
       managers.addAll(Arrays.<ViewManager>asList(
           osmCalloutManager,
@@ -86,7 +89,8 @@ public class MapsPackage implements ReactPackage {
           osmPolygonManager,
           osmMapCircleManager,
           osmMapManager,
-          osmUrlTileManager
+          osmUrlTileManager,
+          osmMapFileTileManager
       ));
     }
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapFileTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapFileTile.java
@@ -2,9 +2,8 @@ package com.airbnb.android.react.maps.osmdroid;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
-import android.widget.Toast;
+import android.util.Log;
 
-import org.osmdroid.config.Configuration;
 import org.osmdroid.tileprovider.modules.ArchiveFileFactory;
 import org.osmdroid.tileprovider.modules.IArchiveFile;
 import org.osmdroid.tileprovider.modules.OfflineTileProvider;
@@ -20,12 +19,14 @@ import java.util.Set;
 
 public class OsmMapFileTile extends OsmMapFeature {
 
+  private final static String TAG = "OsmMapFileTile";
+
   private float maximumZ = 100.f;
   private float minimumZ = 0;
+  private String fileDirPath = "/offline_tiles/";
 
   public OsmMapFileTile(Context context) {
     super(context);
-    Configuration.getInstance().setDebugMode(true);
   }
 
   @Override public void addToMap(MapView map) {
@@ -49,6 +50,10 @@ public class OsmMapFileTile extends OsmMapFeature {
 
   public void setMinimumZ(float minimumZ) {
     this.minimumZ = minimumZ;
+  }
+
+  public void setFileDirPath(String filePath) {
+    this.fileDirPath = filePath;
   }
 
   @NonNull
@@ -77,7 +82,7 @@ public class OsmMapFileTile extends OsmMapFeature {
   private void setupMapProvider(@NonNull MapView map) {
     //first we'll look at the default location for tiles that we support
     Context context = map.getContext();
-    File f = new File(context.getFilesDir() + "/offline_tiles/"); // todo allow parametrization
+    File f = new File(context.getFilesDir() + fileDirPath);
     if (f.exists() && f.isDirectory()) {
 
       File[] list = findAllSupportedFilesInDirectory(f);
@@ -110,17 +115,15 @@ public class OsmMapFileTile extends OsmMapFeature {
           } else {
             map.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
           }
-
-          Toast.makeText(map.getContext(), "Using " + source, Toast.LENGTH_LONG).show();
+          Log.d(TAG, "Using " + source);
           map.invalidate();
           return;
         } catch (Exception ex) {
           ex.printStackTrace();
         }
       } else {
-        Toast.makeText(map.getContext(), f.getAbsolutePath() + " dir not found!", Toast.LENGTH_LONG).show();
+        Log.d(TAG, f.getAbsolutePath() + " dir not found!");
       }
-      Toast.makeText(map.getContext(), f.getAbsolutePath() + " did not have any files I can open! Try using MOBAC", Toast.LENGTH_LONG).show();
     }
   }
 }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapFileTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapFileTile.java
@@ -17,6 +17,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Allows to use offline tile source
+ *
+ * - Put zip file(s) in internal memory: /data/data/{packageName}/files/offline_tiles/
+ * - Internal file subdirectory (offline_tiles) may be changed with setFileDirPath or fileDirPath in
+ * js.
+ * - Every zip must have same root directory, with same name as others: {ROOT_DIR_NAME}/z/X/Y
+ * - Remember to remove hidden os related garbage (like .DS_Store etc.) before creating zip
+ * - Zip files may have any name
+ */
 public class OsmMapFileTile extends OsmMapFeature {
 
   private final static String TAG = "OsmMapFileTile";

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapFileTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapFileTile.java
@@ -14,6 +14,8 @@ import org.osmdroid.tileprovider.util.SimpleRegisterReceiver;
 import org.osmdroid.views.MapView;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 public class OsmMapFileTile extends OsmMapFeature {
@@ -49,84 +51,76 @@ public class OsmMapFileTile extends OsmMapFeature {
     this.minimumZ = minimumZ;
   }
 
+  @NonNull
+  private File[] findAllSupportedFilesInDirectory(File directory) {
+    List<File> candidates = new ArrayList<>();
+    File[] list = directory.listFiles();
+    for (int i = 0; i < list.length; i++) {
+      if (list[i].isDirectory()) {
+        continue;
+      }
+      String name = list[i].getName().toLowerCase();
+      if (!name.contains(".")) {
+        continue; //skip files without an extension
+      }
+      name = name.substring(name.lastIndexOf(".") + 1);
+      if (name.length() == 0) {
+        continue;
+      }
+      if (ArchiveFileFactory.isFileExtensionRegistered(name)) {
+        candidates.add(list[i]);
+      }
+    }
+    return candidates.toArray(new File[0]);
+  }
+
   private void setupMapProvider(@NonNull MapView map) {
     //first we'll look at the default location for tiles that we support
     Context context = map.getContext();
-    File f = new File(context.getFilesDir() + "/offline_tiles/");
-    if (f.exists()) {
+    File f = new File(context.getFilesDir() + "/offline_tiles/"); // todo allow parametrization
+    if (f.exists() && f.isDirectory()) {
 
-      File[] list = f.listFiles();
-      if (list != null) {
-        for (int i = 0; i < list.length; i++) {
-          if (list[i].isDirectory()) {
-            continue;
-          }
-          String name = list[i].getName().toLowerCase();
-          if (!name.contains(".")) {
-            continue; //skip files without an extension
-          }
-          name = name.substring(name.lastIndexOf(".") + 1);
-          if (name.length() == 0) {
-            continue;
-          }
-          if (ArchiveFileFactory.isFileExtensionRegistered(name)) {
-            try {
-
-              //ok found a file we support and have a driver for the format, for this demo, we'll
-              // just use the first one
-
-              //create the offline tile provider, it will only do offline file archives
-              //again using the first file
-              OfflineTileProvider tileProvider =
-                  new OfflineTileProvider(new SimpleRegisterReceiver(map.getContext()),
-                      new File[]{list[i]});
-
-              //tell osmdroid to use that provider instead of the default rig which is (asserts,
-              // cache, files/archives, online
-              map.setTileProvider(tileProvider);
-
-              //this bit enables us to find out what tiles sources are available. note, that this
-              // action may take some time to run
-              //and should be ran asynchronously. we've put it inline for simplicity
-
-              String source = "";
-              IArchiveFile[] archives = tileProvider.getArchives();
-              if (archives.length > 0) {
-                //cheating a bit here, get the first archive file and ask for the tile sources
-                // names it contains
-                Set<String> tileSources = archives[0].getTileSources();
-                //presumably, this would be a great place to tell your users which tiles sources
-                // are available
-                if (!tileSources.isEmpty()) {
-                  //ok good, we found at least one tile source, create a basic file based tile
-                  // source using that name
-                  //and set it. If we don't set it, osmdroid will attempt to use the default
-                  // source, which is "MAPNIK",
-                  //which probably won't match your offline tile source, unless it's MAPNIK
-                  source = tileSources.iterator().next();
-                  map.setTileSource(FileBasedTileSource.getSource(source));
-                } else {
-                  map.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
-                }
-
-              } else {
-                map.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
-              }
-
-              Toast.makeText(map.getContext(), "Using " + list[i].getAbsolutePath() + " " +
-              source,
-                  Toast.LENGTH_LONG).show();
-              map.invalidate();
-              return;
-            } catch (Exception ex) {
-              ex.printStackTrace();
+      File[] list = findAllSupportedFilesInDirectory(f);
+      if (list.length > 0) {
+        try {
+          OfflineTileProvider tileProvider =
+              new OfflineTileProvider(new SimpleRegisterReceiver(map.getContext()), list);
+          map.setTileProvider(tileProvider);
+          // setup tile source
+          String source = "";
+          IArchiveFile[] archives = tileProvider.getArchives();
+          if (archives.length > 0) {
+            //cheating a bit here, get the first archive file and ask for the tile sources
+            // names it contains
+            Set<String> tileSources = archives[0].getTileSources();
+            //presumably, this would be a great place to tell your users which tiles sources
+            // are available
+            if (!tileSources.isEmpty()) {
+              //ok good, we found at least one tile source, create a basic file based tile
+              // source using that name
+              //and set it. If we don't set it, osmdroid will attempt to use the default
+              // source, which is "MAPNIK",
+              //which probably won't match your offline tile source, unless it's MAPNIK
+              source = tileSources.iterator().next();
+              map.setTileSource(FileBasedTileSource.getSource(source));
+            } else {
+              map.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
             }
+
+          } else {
+            map.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
           }
+
+          Toast.makeText(map.getContext(), "Using " + source, Toast.LENGTH_LONG).show();
+          map.invalidate();
+          return;
+        } catch (Exception ex) {
+          ex.printStackTrace();
         }
+      } else {
+        Toast.makeText(map.getContext(), f.getAbsolutePath() + " dir not found!", Toast.LENGTH_LONG).show();
       }
       Toast.makeText(map.getContext(), f.getAbsolutePath() + " did not have any files I can open! Try using MOBAC", Toast.LENGTH_LONG).show();
-    } else {
-      Toast.makeText(map.getContext(), f.getAbsolutePath() + " dir not found!", Toast.LENGTH_LONG).show();
     }
   }
 }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapFileTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapFileTile.java
@@ -1,0 +1,132 @@
+package com.airbnb.android.react.maps.osmdroid;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.widget.Toast;
+
+import org.osmdroid.config.Configuration;
+import org.osmdroid.tileprovider.modules.ArchiveFileFactory;
+import org.osmdroid.tileprovider.modules.IArchiveFile;
+import org.osmdroid.tileprovider.modules.OfflineTileProvider;
+import org.osmdroid.tileprovider.tilesource.FileBasedTileSource;
+import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
+import org.osmdroid.tileprovider.util.SimpleRegisterReceiver;
+import org.osmdroid.views.MapView;
+
+import java.io.File;
+import java.util.Set;
+
+public class OsmMapFileTile extends OsmMapFeature {
+
+  private float maximumZ = 100.f;
+  private float minimumZ = 0;
+
+  public OsmMapFileTile(Context context) {
+    super(context);
+    Configuration.getInstance().setDebugMode(true);
+  }
+
+  @Override public void addToMap(MapView map) {
+    setupMapProvider(map);
+    map.setUseDataConnection(false);
+    map.setTilesScaledToDpi(true);
+  }
+
+  @Override public void removeFromMap(MapView map) {
+    map.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
+    map.setTilesScaledToDpi(true);
+  }
+
+  @Override public Object getFeature() {
+    return null;
+  }
+
+  public void setMaximumZ(float maximumZ) {
+    this.maximumZ = maximumZ;
+  }
+
+  public void setMinimumZ(float minimumZ) {
+    this.minimumZ = minimumZ;
+  }
+
+  private void setupMapProvider(@NonNull MapView map) {
+    //first we'll look at the default location for tiles that we support
+    Context context = map.getContext();
+    File f = new File(context.getFilesDir() + "/offline_tiles/");
+    if (f.exists()) {
+
+      File[] list = f.listFiles();
+      if (list != null) {
+        for (int i = 0; i < list.length; i++) {
+          if (list[i].isDirectory()) {
+            continue;
+          }
+          String name = list[i].getName().toLowerCase();
+          if (!name.contains(".")) {
+            continue; //skip files without an extension
+          }
+          name = name.substring(name.lastIndexOf(".") + 1);
+          if (name.length() == 0) {
+            continue;
+          }
+          if (ArchiveFileFactory.isFileExtensionRegistered(name)) {
+            try {
+
+              //ok found a file we support and have a driver for the format, for this demo, we'll
+              // just use the first one
+
+              //create the offline tile provider, it will only do offline file archives
+              //again using the first file
+              OfflineTileProvider tileProvider =
+                  new OfflineTileProvider(new SimpleRegisterReceiver(map.getContext()),
+                      new File[]{list[i]});
+
+              //tell osmdroid to use that provider instead of the default rig which is (asserts,
+              // cache, files/archives, online
+              map.setTileProvider(tileProvider);
+
+              //this bit enables us to find out what tiles sources are available. note, that this
+              // action may take some time to run
+              //and should be ran asynchronously. we've put it inline for simplicity
+
+              String source = "";
+              IArchiveFile[] archives = tileProvider.getArchives();
+              if (archives.length > 0) {
+                //cheating a bit here, get the first archive file and ask for the tile sources
+                // names it contains
+                Set<String> tileSources = archives[0].getTileSources();
+                //presumably, this would be a great place to tell your users which tiles sources
+                // are available
+                if (!tileSources.isEmpty()) {
+                  //ok good, we found at least one tile source, create a basic file based tile
+                  // source using that name
+                  //and set it. If we don't set it, osmdroid will attempt to use the default
+                  // source, which is "MAPNIK",
+                  //which probably won't match your offline tile source, unless it's MAPNIK
+                  source = tileSources.iterator().next();
+                  map.setTileSource(FileBasedTileSource.getSource(source));
+                } else {
+                  map.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
+                }
+
+              } else {
+                map.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
+              }
+
+              Toast.makeText(map.getContext(), "Using " + list[i].getAbsolutePath() + " " +
+              source,
+                  Toast.LENGTH_LONG).show();
+              map.invalidate();
+              return;
+            } catch (Exception ex) {
+              ex.printStackTrace();
+            }
+          }
+        }
+      }
+      Toast.makeText(map.getContext(), f.getAbsolutePath() + " did not have any files I can open! Try using MOBAC", Toast.LENGTH_LONG).show();
+    } else {
+      Toast.makeText(map.getContext(), f.getAbsolutePath() + " dir not found!", Toast.LENGTH_LONG).show();
+    }
+  }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapFileTileManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapFileTileManager.java
@@ -1,0 +1,39 @@
+package com.airbnb.android.react.maps.osmdroid;
+
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+public class OsmMapFileTileManager extends ViewGroupManager<OsmMapFileTile> {
+
+  public OsmMapFileTileManager() {
+    super();
+  }
+
+  @Override
+  public String getName() {
+    return "OsmMapFileTile";
+  }
+
+  @Override
+  public OsmMapFileTile createViewInstance(ThemedReactContext context) {
+    return new OsmMapFileTile(context);
+  }
+
+  @ReactProp(name = "minimumZ", defaultFloat = 0.0f)
+  public void setMinimumZ(OsmMapFileTile view, float minimumZ) {
+    view.setMinimumZ(minimumZ);
+  }
+
+  @ReactProp(name = "maximumZ", defaultFloat = 100.0f)
+  public void setMaximumZ(OsmMapFileTile view, float maximumZ) {
+    view.setMaximumZ(maximumZ);
+  }
+
+  // todo create offline placeholder binding\
+  //         //https://github.com/osmdroid/osmdroid/issues/330
+  //        //custom image placeholder for files that aren't available
+  //        mMapView.getTileProvider().setTileLoadFailureImage(getResources().getDrawable(R
+  //        .drawable.notfound));
+
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapFileTileManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapFileTileManager.java
@@ -30,6 +30,11 @@ public class OsmMapFileTileManager extends ViewGroupManager<OsmMapFileTile> {
     view.setMaximumZ(maximumZ);
   }
 
+  @ReactProp(name="fileDirPath")
+  public void setFilePath(OsmMapFileTile view, String fileDirPath) {
+    view.setFileDirPath(fileDirPath);
+  }
+
   // todo create offline placeholder binding\
   //         //https://github.com/osmdroid/osmdroid/issues/330
   //        //custom image placeholder for files that aren't available

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapView.java
@@ -9,6 +9,7 @@ import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.View;
+import android.widget.Toast;
 
 import com.airbnb.android.react.maps.osmdroid.overlays.InterceptDoubleTapOverlay;
 import com.airbnb.android.react.maps.osmdroid.overlays.InterceptScrollOverlay;
@@ -74,7 +75,6 @@ public class OsmMapView extends MapView implements MapView.OnFirstLayoutListener
                       ReactApplicationContext appContext,
                       OsmMapManager manager) {
         super(reactContext.getApplicationContext());
-
         this.manager = manager;
         this.context = reactContext;
         this.addOnFirstLayoutListener(this);
@@ -295,6 +295,10 @@ public class OsmMapView extends MapView implements MapView.OnFirstLayoutListener
             OsmMapUrlTile urlTileView = (OsmMapUrlTile) child;
             urlTileView.addToMap(this);
             features.add(index, urlTileView);
+        } else if (child instanceof OsmMapFileTile) {
+            OsmMapFileTile filetileView = (OsmMapFileTile) child;
+            filetileView.addToMap(this);
+            features.add(index, filetileView);
         } else if (child instanceof OsmMapCircle) {
             OsmMapCircle circleView = (OsmMapCircle) child;
             circleView.addToMap(this);

--- a/lib/components/MapFileTile.js
+++ b/lib/components/MapFileTile.js
@@ -1,0 +1,79 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {
+  ViewPropTypes,
+  View,
+} from 'react-native';
+
+import decorateMapComponent, {
+  USES_DEFAULT_IMPLEMENTATION,
+  SUPPORTED,
+} from './decorateMapComponent';
+
+// if ViewPropTypes is not defined fall back to View.propType (to support RN < 0.44)
+const viewPropTypes = ViewPropTypes || View.propTypes;
+
+const propTypes = {
+  ...viewPropTypes,
+
+  /**
+   * The order in which this tile overlay is drawn with respect to other overlays. An overlay
+   * with a larger z-index is drawn over overlays with smaller z-indices. The order of overlays
+   * with the same z-index is arbitrary. The default zIndex is -1.
+   *
+   * @platform android
+   */
+  zIndex: PropTypes.number,
+  /**
+   * The maximum zoom level for this tile overlay.
+   *
+   */
+  maximumZ: PropTypes.number,
+
+  /**
+   * The minimum zoom level for this tile overlay.
+   *
+   */
+  minimumZ: PropTypes.number,
+
+  /**
+   * Corresponds to MKTileOverlay canReplaceMapContent.
+   *
+   * @platform ios
+   */
+  shouldReplaceMapContent: PropTypes.bool,
+
+  /**
+   * (Optional) Tile size for iOS only, default size is 256 * 256.
+   *
+   * @platform ios
+   */
+  tileSize: PropTypes.number,
+};
+
+class MapFileTile extends React.Component {
+  render() {
+    const AIRMapUrlTile = this.getAirComponent();
+    return (
+      <AIRMapUrlTile
+        {...this.props}
+      />
+    );
+  }
+}
+
+MapFileTile.propTypes = propTypes;
+
+export default decorateMapComponent(MapFileTile, {
+  componentType: 'FileTile',
+  providers: {
+    google: {
+      ios: SUPPORTED,
+      android: SUPPORTED,
+    },
+    osmdroid: {
+      android: USES_DEFAULT_IMPLEMENTATION,
+    },
+  },
+});

--- a/lib/components/MapFileTile.js
+++ b/lib/components/MapFileTile.js
@@ -70,10 +70,6 @@ MapFileTile.propTypes = propTypes;
 export default decorateMapComponent(MapFileTile, {
   componentType: 'FileTile',
   providers: {
-    google: {
-      ios: SUPPORTED,
-      android: SUPPORTED,
-    },
     osmdroid: {
       android: USES_DEFAULT_IMPLEMENTATION,
     },

--- a/lib/components/MapFileTile.js
+++ b/lib/components/MapFileTile.js
@@ -17,6 +17,8 @@ const viewPropTypes = ViewPropTypes || View.propTypes;
 const propTypes = {
   ...viewPropTypes,
 
+  fileDirPath: PropTypes.string,
+
   /**
    * The order in which this tile overlay is drawn with respect to other overlays. An overlay
    * with a larger z-index is drawn over overlays with smaller z-indices. The order of overlays

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -18,6 +18,7 @@ import MapCircle from './MapCircle';
 import MapCallout from './MapCallout';
 import MapOverlay from './MapOverlay';
 import MapUrlTile from './MapUrlTile';
+import MapFileTile from './MapFileTile';
 import MapLocalTile from './MapLocalTile';
 import AnimatedRegion from './AnimatedRegion';
 import {
@@ -946,6 +947,7 @@ MapView.Polyline = MapPolyline;
 MapView.Polygon = MapPolygon;
 MapView.Circle = MapCircle;
 MapView.UrlTile = MapUrlTile;
+MapView.FileTile = MapFileTile;
 MapView.LocalTile = MapLocalTile;
 MapView.Overlay = MapOverlay;
 MapView.Callout = MapCallout;


### PR DESCRIPTION
### Does any other open PR do the same thing?
Probably no. I was requested to assist with offline maps to our in house RN team (I'm native dev).

### What issue is this PR fixing?
Library user may decide to build map with tiles stored manually in internal storage. It's all based on features already present in OSM native implementation.

### How did you test this PR?
It was used in app developed for our client, so far it works. You may test it LocalCustomTiles.js that may be started from sample list. But first you have to place proper zip with tiles here: `/data/data/{packageName}/files/offline_tiles/`